### PR TITLE
flat-colors 3.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![flat-colors](http://i.imgur.com/S57IeyN.png)](#)
 
-# flat-colors [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Travis](https://img.shields.io/travis/IonicaBizau/flat-colors.js.svg)](https://travis-ci.org/IonicaBizau/flat-colors.js/) [![Version](https://img.shields.io/npm/v/flat-colors.svg)](https://www.npmjs.com/package/flat-colors) [![Downloads](https://img.shields.io/npm/dt/flat-colors.svg)](https://www.npmjs.com/package/flat-colors) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# flat-colors
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Travis](https://img.shields.io/travis/IonicaBizau/flat-colors.js.svg)](https://travis-ci.org/IonicaBizau/flat-colors.js/) [![Version](https://img.shields.io/npm/v/flat-colors.svg)](https://www.npmjs.com/package/flat-colors) [![Downloads](https://img.shields.io/npm/dt/flat-colors.svg)](https://www.npmjs.com/package/flat-colors) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Find the nearest flat color for a RGB/Hex input.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flat-colors",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "Find the nearest flat color for a RGB/Hex input.",
   "main": "lib/index.js",
   "scripts": {
@@ -44,6 +44,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
